### PR TITLE
feat: skip funnel-ingress-node peers for inventory

### DIFF
--- a/ansible-tailscale-inventory.py
+++ b/ansible-tailscale-inventory.py
@@ -31,6 +31,9 @@ all_hosts.append(
 )
 
 for v in all_hosts:
+    if v["HostName"] == "funnel-ingress-node":
+        continue
+
     inventory["all"]["hosts"].append(v["HostName"])
 
     inventory["_meta"]["hostvars"][v["HostName"]] = {


### PR DESCRIPTION
Hi @m4wh6k 

Thank you very much for sharing this inventory script! It came in handy for a project I'm currently working on. But when I wanted to use the script in my tailnet, I discovered something that I'd consider a bug in the script:

Since ansible v2.6.2 inventory scripts that produce groups named "" will fail to parse (see https://github.com/ansible/ansible/pull/42584 for upstream PR)

With the introduction of Tailscale funnel, your tailnet can contain a peer 'funnnel-ingress-node' (only if you are using the funnel feature actively) this peer can't be matched to any group in your script and thus creates a group named "" which means that ansible can't parse the returned JSON and will fail.

To fix this I added a simple if statment to skip adding this peer to the inventory if it appears.

For more information about tailscale funnel see [their blog post](https://tailscale.com/blog/introducing-tailscale-funnel/).

What do you think?