### PR TITLE
fix: replace all dashes with underscore

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and Linux, but not Windows.
 group
 - The `self` group includes the local host
 - Each Tailscale tag that has at least one host will be a group as well. The
-  name will be formatted as `tag_TagName`
+  name will be formatted as `tag_TagName` (dashes will be replace with underscores)
 
 ## Inventory Metadata
 The inventory automatically adds all available Tailscale IPs as a list in the

--- a/ansible-tailscale-inventory.py
+++ b/ansible-tailscale-inventory.py
@@ -52,7 +52,7 @@ for v in all_hosts:
 
     if "Tags" in v:
         for tag in v["Tags"]:
-            safe_tag = tag.replace(":", "_")
+            safe_tag = tag.replace(":", "_").replace("-", "_")
             if safe_tag in inventory:
                 inventory[safe_tag]["hosts"].append(v["HostName"])
             else:


### PR DESCRIPTION
I discovered a problem:
- Ansible group names only allow numbers, letters, or underscores
- Tailscale tag names only allow numbers, letters, or dashes

What do you think about replacing all dashes with underscores, to allow existing tags to be used without modification?

At least in my manual checks, the proposed change works ;)