### PR TITLE
Skip nodes with no OS field set

### DIFF
--- a/ansible_tailscale_inventory.py
+++ b/ansible_tailscale_inventory.py
@@ -169,6 +169,9 @@ def assemble_inventory(
         if host_data["HostName"] == "funnel-ingress-node":
             continue
 
+        if not host_data["OS"]:
+            continue
+
         # We add each host to the list of all hosts
         inventory["groups"]["all"].append(host_data["HostName"])
 


### PR DESCRIPTION
Mullvad exit nodes have empty OS field which causes Ansible to throw an error as the OS field is parsed into a group name and empty group names are no longer allowed. Given that Tailscale users won't actually run Ansible on the Mullvad servers we can just skip them altogether.